### PR TITLE
logical validation groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,3 +7,4 @@ Author
 
 Patches and Suggestions
 - - - - - - - - - - - -
+* Jannik Kramer \<<mail@jannikkramer.de\> [@jannik-kramer](https://github.com/jannik-kramer)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Table of Contents
     * [Recursive Validations](#recursive-validations)
     * [Strict Validator](#strict-validator)
     * [Allow Nil Validator Instance](#allow-nil-validator-instance)
+    * [Logic Group Validation](#logic-group-validation)
 * [Why Another Validation Package?](#why-another-validation-package)
 * [How to Contribute](#how-to-contribute)
 
@@ -429,6 +430,38 @@ book := &Book{
 
 err = book.Validate()
 // err -> nil
+```
+
+### Logic Group Validation
+
+```golang
+import (
+	"github.com/nauyey/guard"
+	"github.com/nauyey/guard/validators"
+)
+
+type Server struct {
+	Keyfile  string
+	Password string
+}
+
+// Validate implements interface guard.Validator
+func (server *Server) Validate() error {
+	return guard.Validate(
+	    guard.Xor(
+		    &validators.StringNotBlank{Value: user.Keyfile},
+		    &validators.StringNotBlank{Value: user.Password},
+	    ),
+	)
+}
+
+server := &Server{
+    Keyfile: "/id_rsa",
+    Password: "3gj)s0dß?=§F")=3f",
+}
+
+err = sser.Validate()
+// err -> not nil
 ```
 
 ---------------------------------------

--- a/README.md
+++ b/README.md
@@ -456,11 +456,11 @@ func (server *Server) Validate() error {
 }
 
 server := &Server{
-    Keyfile: "/id_rsa",
+    Keyfile:  "/id_rsa",
     Password: "3gj)s0dß?=§F")=3f",
 }
 
-err = sser.Validate()
+err = server.Validate()
 // err -> not nil
 ```
 

--- a/logic_validations.go
+++ b/logic_validations.go
@@ -1,0 +1,85 @@
+package guard
+
+import (
+	"guard/validators"
+)
+
+const (
+	atLeastOneMsg = "at leat one" // OR
+	onlyOneMsg = "only one" // XOR
+	notAllMsg = "not all" // NAND
+)
+
+type (
+	orValidation struct {
+		validators []Validator
+	}
+	xorValidation struct {
+		validators []Validator
+	}
+	nandValidation struct {
+		validators []Validator
+	}
+)
+
+
+// Or wraps validators in a group in which
+// *at least one* of the validators is allowed to pass.
+func Or(validators ...Validator) Validator {
+	return &orValidation{
+		validators: validators,
+	}
+}
+
+// Validate implements the Validator interface
+func (v *orValidation) Validate() error {
+	// evaluate validators inside or-group
+	errs := Validate(v.validators...)
+
+	if errs != nil && len(v.validators)-len(errs.(Errors).ValidationErrors()) == 0 {
+		return validators.ReturnGenericError(atLeastOneMsg)
+	}
+
+	return nil
+}
+
+// Xor wraps validators in a group in which
+// *only one* of the validators is allowed to pass.
+func Xor(validators ...Validator) Validator {
+	return &xorValidation{
+		validators: validators,
+	}
+}
+
+// Validate implements the Validator interface
+func (v *xorValidation) Validate() error {
+	// evaluate validators inside xor-group
+	errs := Validate(v.validators...)
+
+	if errs == nil || len(v.validators)-len(errs.(Errors).ValidationErrors()) != 1 {
+		return validators.ReturnGenericError(onlyOneMsg)
+	}
+
+	return nil
+}
+
+// Nand wraps validators in a group in which
+// *not all* of the validators are allowed pass.
+func Nand(validators ...Validator) Validator {
+	return &nandValidation{
+		validators: validators,
+	}
+}
+
+// Validate implements the Validator interface
+func (v *nandValidation) Validate() error {
+	// evaluate validators inside nand-group
+	errs := Validate(v.validators...)
+
+	// no error -> all have passed -> error
+	if errs == nil {
+		return validators.ReturnGenericError(notAllMsg)
+	}
+
+	return nil
+}

--- a/logic_validations.go
+++ b/logic_validations.go
@@ -6,8 +6,8 @@ import (
 
 const (
 	atLeastOneMsg = "at leat one" // OR
-	onlyOneMsg = "only one" // XOR
-	notAllMsg = "not all" // NAND
+	onlyOneMsg    = "only one"    // XOR
+	notAllMsg     = "not all"     // NAND
 )
 
 type (
@@ -21,7 +21,6 @@ type (
 		validators []Validator
 	}
 )
-
 
 // Or wraps validators in a group in which
 // *at least one* of the validators is allowed to pass.

--- a/logic_validations.go
+++ b/logic_validations.go
@@ -1,7 +1,7 @@
 package guard
 
 import (
-	"guard/validators"
+	"github.com/nauyey/guard/validators"
 )
 
 const (

--- a/logic_validations_test.go
+++ b/logic_validations_test.go
@@ -1,0 +1,121 @@
+package guard_test
+
+import (
+	"github.com/nauyey/guard"
+	"github.com/nauyey/guard/validators"
+	"testing"
+)
+
+func TestOrValidator(t *testing.T) {
+	err := guard.Validate(
+		guard.Or(
+			&validators.StringNotBlank{Value: ""},
+			&validators.StringNotBlank{Value: ""},
+			&validators.StringNotBlank{Value: ""},
+		),
+	)
+
+	if err == nil {
+		t.Errorf("guard.Or failed to revolse none having passed correctly")
+	}
+
+	err = guard.Validate(
+		guard.Or(
+			&validators.StringNotBlank{Value: "NOT BLANK"},
+			&validators.StringNotBlank{Value: ""},
+			&validators.StringNotBlank{Value: ""},
+		),
+	)
+
+	if err != nil {
+		t.Errorf("guard.Or failed to resolve one having passed correctly")
+	}
+
+	err = guard.Validate(
+		guard.Or(
+			&validators.StringNotBlank{Value: "NOT BLANK"},
+			&validators.StringNotBlank{Value: "NOT BLANK"},
+			&validators.StringNotBlank{Value: "NOT BLANK"},
+		),
+	)
+
+	if err != nil {
+		t.Errorf("guard.Or failed to resolve all having passed correctly")
+	}
+}
+
+func TestXorValidator(t *testing.T) {
+	err := guard.Validate(
+		guard.Xor(
+			&validators.StringNotBlank{Value: ""},
+			&validators.StringNotBlank{Value: ""},
+			&validators.StringNotBlank{Value: ""},
+		),
+	)
+
+	if err == nil {
+		t.Errorf("guard.Xor failed to resolve to few having passed correctly")
+	}
+
+	err = guard.Validate(
+		guard.Xor(
+			&validators.StringNotBlank{Value: ""},
+			&validators.StringNotBlank{Value: "ONLY_ONE"},
+			&validators.StringNotBlank{Value: "ONLY_ONE"},
+		),
+	)
+
+	if err == nil {
+		t.Errorf("guard.Xor failed to resolve to many having passed correctly")
+	}
+
+	err = guard.Validate(
+		guard.Xor(
+			&validators.StringNotBlank{Value: ""},
+			&validators.StringNotBlank{Value: "ONLY_ONE"},
+			&validators.StringNotBlank{Value: ""},
+		),
+	)
+
+	if err != nil {
+		t.Errorf("guard.Xor failed to resolve only one having passed correctly")
+	}
+}
+
+func TestNandValidator(t *testing.T) {
+	err := guard.Validate(
+		guard.Nand(
+			&validators.StringNotBlank{Value: ""},
+			&validators.StringNotBlank{Value: ""},
+			&validators.StringNotBlank{Value: ""},
+		),
+	)
+
+	if err != nil {
+		t.Errorf("guard.Xor failed to resolve none having passed correctly")
+	}
+
+	err = guard.Validate(
+		guard.Nand(
+			&validators.StringNotBlank{Value: ""},
+			&validators.StringNotBlank{Value: "ONLY_ONE"},
+			&validators.StringNotBlank{Value: "ONLY_ONE"},
+		),
+	)
+
+	if err != nil {
+		t.Errorf("guard.Xor failed to resolve not all but one having passed correctly")
+	}
+
+	err = guard.Validate(
+		guard.Nand(
+			&validators.StringNotBlank{Value: "ONLY_ONE"},
+			&validators.StringNotBlank{Value: "ONLY_ONE"},
+			&validators.StringNotBlank{Value: "ONLY_ONE"},
+		),
+	)
+
+	if err == nil {
+		t.Errorf("guard.Xor failed to resolve all having passed correctly")
+	}
+}

--- a/validators/utils.go
+++ b/validators/utils.go
@@ -16,3 +16,7 @@ func returnDefaultStringIfNil(s *string, d string) string {
 	}
 	return d
 }
+
+func ReturnGenericError(s string) error {
+	return &validationError{s}
+}

--- a/validators/utils.go
+++ b/validators/utils.go
@@ -17,6 +17,7 @@ func returnDefaultStringIfNil(s *string, d string) string {
 	return d
 }
 
+// ReturnGenericError provides errors for validations outside the validators packages
 func ReturnGenericError(s string) error {
 	return &validationError{s}
 }


### PR DESCRIPTION
By grouping validators into OR-, XOR- or NAND-Groups more complex validations can be created. Example use case would be a CLI where either a keyfile or a password can be set, but not both (xor). I tried to follow the code style as close as possible.
Note:
- I had to create a public function in the validators package to be able to create errors in the guard package.
- Currently message overwrite is not supported. This could be addressed in the large update, where error message batch overwrite is implemented.

Related: #4
